### PR TITLE
Fixed XSS vulnerability working on inserting HTML-Code into Script-URL

### DIFF
--- a/frontend/UPwdChg.php
+++ b/frontend/UPwdChg.php
@@ -1665,7 +1665,7 @@ class UPwdChg
     switch($sID) {
 
     case 'reset':
-      $sHTML .= '<FORM ID="UPwdChg_reset" METHOD="post" ACTION="'.$_SERVER['SCRIPT_NAME'].'">';
+      $sHTML .= '<FORM ID="UPwdChg_reset" METHOD="post" ACTION="/index.php">';
       $sHTML .= '<INPUT TYPE="hidden" NAME="do" VALUE="reset" />';
       $sHTML .= '<TABLE CELLSPACING="0">';
       $sHTML .= '<TR><TD CLASS="link" COLSPAN="2"><A HREF="javascript:;" ONCLICK="javascript:document.getElementById(\'UPwdChg_reset\').submit();">'.htmlentities($this->getText('label:reset')).'</A></TD></TR>';
@@ -1677,7 +1677,7 @@ class UPwdChg
       $sCurrentLocale = $this->getCurrentLocale();
 
       // ... HTML
-      $sHTML .= '<FORM ID="UPwdChg_locale" METHOD="post" ACTION="'.$_SERVER['SCRIPT_NAME'].'">';
+      $sHTML .= '<FORM ID="UPwdChg_locale" METHOD="post" ACTION="/index.php">';
       $sHTML .= '<INPUT TYPE="hidden" NAME="do" VALUE="locale" />';
       $sHTML .= '<TABLE CELLSPACING="0"><TR>';
       $sHTML .= '<TD CLASS="label">'.htmlentities($this->getText('label:language')).':</TD>';
@@ -1697,7 +1697,7 @@ class UPwdChg
       }
 
       // ... HTML
-      $sHTML .= '<FORM ID="UPwdChg_form" METHOD="post" ACTION="'.$_SERVER['SCRIPT_NAME'].'?view=captcha'.($sBack ? '&back='.$sBack : null).'">';
+      $sHTML .= '<FORM ID="UPwdChg_form" METHOD="post" ACTION="/index.php'.'?view=captcha'.($sBack ? '&back='.$sBack : null).'">';
       $sHTML .= '<INPUT TYPE="hidden" NAME="do" VALUE="captcha" />';
       $sHTML .= '<TABLE CELLSPACING="0"><TR>';
       $iTabIndex = 1;
@@ -1778,7 +1778,7 @@ class UPwdChg
       }
 
       // ... HTML
-      $sHTML .= '<FORM ID="UPwdChg_form" METHOD="post" ACTION="'.$_SERVER['SCRIPT_NAME'].'?view=password-nonce-request">';
+      $sHTML .= '<FORM ID="UPwdChg_form" METHOD="post" ACTION="/index.php?view=password-nonce-request">';
       $sHTML .= '<INPUT TYPE="hidden" NAME="do" VALUE="password-nonce-request" />';
       $sHTML .= '<TABLE CELLSPACING="0">';
       $iTabIndex = 1;
@@ -1816,7 +1816,7 @@ class UPwdChg
       }
 
       // ... HTML
-      $sHTML .= '<FORM ID="UPwdChg_form" METHOD="post" ACTION="'.$_SERVER['SCRIPT_NAME'].'?view=password-change">';
+      $sHTML .= '<FORM ID="UPwdChg_form" METHOD="post" ACTION="/index.php?view=password-change">';
       $sHTML .= '<INPUT TYPE="hidden" NAME="do" VALUE="password-change" />';
       $sHTML .= '<INPUT TYPE="password" NAME="autocomplete_off" STYLE="DISPLAY:none;" />';
       if(!$bFormPasswordNonce)
@@ -1865,7 +1865,7 @@ class UPwdChg
       }
 
       // ... HTML
-      $sHTML .= '<FORM ID="UPwdChg_form" METHOD="post" ACTION="'.$_SERVER['SCRIPT_NAME'].'?view=password-reset">';
+      $sHTML .= '<FORM ID="UPwdChg_form" METHOD="post" ACTION="/index.php?view=password-reset">';
       $sHTML .= '<INPUT TYPE="hidden" NAME="do" VALUE="password-reset" />';
       $sHTML .= '<INPUT TYPE="password" NAME="autocomplete_off" STYLE="DISPLAY:none;" />';
       $sHTML .= '<TABLE CELLSPACING="0">';


### PR DESCRIPTION
This fixes a XSS vulnerability that uses a specially formed (albeit not complicated) URL which is evaluated by the PHP-script with no sanity checking:

I.e. https://DOMAINNAME.TLD/index.php?view=password-change%22%3c%2f%46%4f%52%4d%3e%3c%73%63%72%69%70%74%3e%61%6c%65%72%74%28%22%58%53%53%20%42%59%20%41%4e%59%31%22%29%3c%2f%73%63%72%69%70%74%3e
(this launches a JavaScript alert containing the words "XSS BY ANY1")

Since the offending lines that make this attack work (`'.$_SERVER['SCRIPT_NAME'].'`) all try to populate the resulting HTML with the same and a-priori knowable value (`index.php`), the lines can be changed to hard-coded values without problem.

Thanks go to @hessandrew for finding and informing me about this vulnerability.